### PR TITLE
Pipe and redirs now work after cmds w/o a white space

### DIFF
--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: aprevrha <aprevrha@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 13:59:26 by aprevrha          #+#    #+#             */
-/*   Updated: 2024/03/13 17:05:54 by aprevrha         ###   ########.fr       */
+/*   Updated: 2024/03/13 17:51:18 by aprevrha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,6 +116,8 @@ void	expand(void *token)
 	char			*str;
 	int				quote;
 
+	if (((t_token *)token)->type == PIPE)
+		return ;
 	str = ((t_token *)token)->value;
 	quote = 0;
 	i = 0;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -6,7 +6,7 @@
 /*   By: aprevrha <aprevrha@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/07 13:59:26 by aprevrha          #+#    #+#             */
-/*   Updated: 2024/03/10 22:05:11 by aprevrha         ###   ########.fr       */
+/*   Updated: 2024/03/13 17:54:01 by aprevrha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ t_token	*lex_cmd(const char *line, unsigned int *i)
 	if (!token)
 		return (NULL);
 	lex_len = 0;
-	skip_until(&line[*i], &lex_len, " ", true);
+	skip_until(&line[*i], &lex_len, " |<>", true);
 	token->type = CMD;
 	token->value = ft_substr(line, *i, lex_len);
 	if (!(token->value))

--- a/tests/test_lexer.c
+++ b/tests/test_lexer.c
@@ -6,7 +6,7 @@
 /*   By: aprevrha <aprevrha@student.42vienna.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/06 17:19:38 by hrother           #+#    #+#             */
-/*   Updated: 2024/03/13 17:13:35 by aprevrha         ###   ########.fr       */
+/*   Updated: 2024/03/13 17:31:36 by aprevrha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ int	test_lexer(char **envp)
 
 	log_msg(WARNING, "This test needs manual inspection of the output");
 	(void)envp;
-	line = "echo";
+	line = "'ec''ho'|cat -e";
 	token_lst = lexer(line);
 	ft_lstiter(token_lst, print_token_new);
 	return (SUCCESS);


### PR DESCRIPTION
closes #41
Special chars such as |, <, > now correctly work right after a command.
Also fixed lexer crash caused by trying to expand pipes.